### PR TITLE
Fixes DefaultTokenAuthorityService not taking advantage of internal jwks cache of RemoteJWKSet

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -92,6 +92,7 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
   private RSAPrivateKey signingKey;
 
   private Optional<String> cachedSigningKeyID = Optional.empty();
+  private final Map<String, JWKSource<SecurityContext>> jwkSourceCache = new HashMap<String, JWKSource<SecurityContext>>();
 
   public void setKeystoreService(KeystoreService ks) {
     this.keystoreService = ks;
@@ -219,8 +220,6 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
       throw new TokenServiceException("Cannot verify token.", e);
     }
   }
-
-  private final Map<String, JWKSource<SecurityContext>> jwkSourceCache = new HashMap<String, JWKSource<SecurityContext>>();
   
   @Override
   public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -220,7 +220,7 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
       throw new TokenServiceException("Cannot verify token.", e);
     }
   }
-  
+
   @Override
   public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {
     boolean verified = false;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -220,13 +220,15 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
     }
   }
 
+  private final Map<String, JWKSource<SecurityContext>> jwkSourceCache = new HashMap<String, JWKSource<SecurityContext>>();
+  
   @Override
   public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {
     boolean verified = false;
     try {
       if (algorithm != null && jwksurl != null) {
         JWSAlgorithm expectedJWSAlg = JWSAlgorithm.parse(algorithm);
-        JWKSource<SecurityContext> keySource = new RemoteJWKSet<>(new URL(jwksurl));
+        JWKSource<SecurityContext> keySource = jwkSourceCache.computeIfAbsent(jwksurl, k -> new RemoteJWKSet<>(new URL(k)));
         JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, keySource);
 
         // Create a JWT processor for the access tokens


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

This PR eliminates the continuous reinstantiation of the `RemoteJWKSet` class. `RemoteJWKSet` has some internal caching that reduces the amount of calls to the jwks source, but due to the constant reinstantiation the cache is not used. This PR caches the use of the `RemoteJWKSet` in order to fully leverage the jwks cache (https://github.com/felx/nimbus-jose-jwt/blob/master/src/main/java/com/nimbusds/jose/jwk/source/RemoteJWKSet.java#L42).

## How was this patch tested?

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
